### PR TITLE
[MI-2415] Bump plugin version

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "name": "Servicenow Plugin",
     "description": "This plugin serves as an integration between Mattermost and ServiceNow.",
     "icon_path": "assets/starter-template-icon.svg",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "min_server_version": "5.37.0",
     "server": {
         "executables": {

--- a/server/plugin/manifest.go
+++ b/server/plugin/manifest.go
@@ -7,5 +7,5 @@ var manifest = struct {
 	Version string
 }{
 	ID:      "mattermost-plugin-servicenow",
-	Version: "2.3.1",
+	Version: "2.3.2",
 }


### PR DESCRIPTION
Release notes:

1. Modified the update set to fix the issue while committing.
2. Show the RHS header when subscriptions are not configured/authorized.